### PR TITLE
Throw error if Node version is below 18

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const { Server } = require("socket.io");
 const { io } = require("socket.io-client");
 const term = require( 'terminal-kit' ).terminal;
 const Downloader = require("nodejs-file-downloader");
+const semver = require('semver');
 const platform = os.platform()
 const shell = platform === 'win32' ? 'powershell.exe' : 'bash';
 class Dalai {
@@ -117,6 +118,12 @@ class Dalai {
     return modelNames
   }
   async install(...models) {
+    // Check if current version is greater than or equal to 18
+    const node_version = process.version;
+    if (!semver.gte(node_version, '18.0.0')) {
+      throw new Error("outdated Node version, please install Node 18 or newer")
+    }
+
     // install llama.cpp to home
     let success = await this.exec(`git clone https://github.com/ggerganov/llama.cpp.git ${this.home}`)
     if (!success) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "express": "^4.18.2",
         "node-pty": "^0.10.1",
         "nodejs-file-downloader": "^4.10.6",
+        "semver": "^7.3.8",
         "socket.io": "^4.6.1",
         "socket.io-client": "^4.6.1",
         "terminal-kit": "^3.0.0"
@@ -721,6 +722,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -1001,6 +1013,20 @@
       "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -1331,6 +1357,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
     "just:fix": "npx prettier --write ."
   },
   "dependencies": {
+    "ejs": "^3.1.8",
+    "express": "^4.18.2",
     "node-pty": "^0.10.1",
     "nodejs-file-downloader": "^4.10.6",
+    "semver": "^7.3.8",
     "socket.io": "^4.6.1",
     "socket.io-client": "^4.6.1",
-    "terminal-kit": "^3.0.0",
-    "ejs": "^3.1.8",
-    "express": "^4.18.2"
+    "terminal-kit": "^3.0.0"
   },
   "devDependencies": {
     "prettier": "^2.8.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,6 +462,13 @@ lazyness@^1.2.0:
   resolved "https://registry.npmjs.org/lazyness/-/lazyness-1.2.0.tgz"
   integrity sha512-KenL6EFbwxBwRxG93t0gcUyi0Nw0Ub31FJKN1laA4UscdkL1K1AxUd0gYZdcLU3v+x+wcFi4uQKS5hL+fk500g==
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
@@ -665,6 +672,13 @@ sanitize-filename@^1.6.3:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.18.0:
   version "0.18.0"
   resolved "https://registry.npmjs.org/send/-/send-0.18.0.tgz"
@@ -847,3 +861,8 @@ xmlhttprequest-ssl@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz"
   integrity sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
Fixes #42 #41 #17

Many people experience errors because of old Node versions. With this, the script could throw an error if the Node version is below 18 (current LTS release).

It checks the version string via the [semver package](https://www.npmjs.com/package/semver). This might be a bit overkill but it can account for weird version strings and such.