### PR TITLE
Enable download retries

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ class Dalai {
       const task = `downloading ${file}`
       const downloader = new Downloader({
         url: `https://agi.gpt4.org/llama/LLaMA/${model}/${file}`,
+        maxAttempts: 10,
         directory: path.resolve(this.home, "models", model),
         onProgress: (percentage, chunk, remainingSize) => {
           this.progress(task, percentage)


### PR DESCRIPTION
This PR enables automatic retries in the downloader, which fixed a problem where the connection would reset during download on a slow internet connection.
After making this change the 65B model eventually completed successfully