### PR TITLE
Ignore the model/.cpp directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ venv
 node_modules
 llama.cpp
 package-lock.json
+llama/
+alpaca/


### PR DESCRIPTION
Simple update to .gitignore to ignore the llama and alpaca directories where the .cpp and the models are pulled into.