### PR TITLE
Update docker-compose.yml to reuse existing models

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,5 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - ./models/alpaca:/root/dalai/alpaca
-      - ./models/llama:/root/dalai/llama
+      - ./alpaca:/root/dalai/alpaca
+      - ./llama:/root/dalai/llama

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,7 +120,7 @@ docker compose run dalai npx dalai alpaca install 7B # or a different model
 docker compose up -d
 ```
 
-This will dave the models in the `./models` folder
+This will save the models in the `./alpaca` and `./llama` folders
 
 View the site at http://127.0.0.1:3000/
 


### PR DESCRIPTION
If the user already has downloaded some models, then docker will use these instead of making a new directory for them