### PR TITLE
Fix model path

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,7 +225,7 @@ class Dalai {
       seed: req.seed || -1,
       threads: req.threads || 8,
       n_predict: req.n_predict || 128,
-      model: `models/${Model || "7B"}/ggml-model-q4_0.bin`,
+      model: `${Core}/models/${Model || "7B"}/ggml-model-q4_0.bin`,
     }
 
     let e = await exists(path.resolve(this.home, Core, "models", Model))

--- a/index.js
+++ b/index.js
@@ -225,7 +225,7 @@ class Dalai {
       seed: req.seed || -1,
       threads: req.threads || 8,
       n_predict: req.n_predict || 128,
-      model: `${Core}/models/${Model || "7B"}/ggml-model-q4_0.bin`,
+      model: `${path.resolve(this.home, Core, "models", Model || '7B')}/ggml-model-q4_0.bin`,
     }
 
     let e = await exists(path.resolve(this.home, Core, "models", Model))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dalai",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "",
   "main": "index.js",
   "author": "cocktailpeanut",


### PR DESCRIPTION
Hi all,

As I can see the path of the model in command is wrong.

⛔ 
```
/root/dalai/alpaca/main --seed -1 --threads 4 --n_predict 200 --model models/13B/ggml-model-q4_0.bin --top_k 40 --top_p 0.9 --temp 0.8 --repeat_last_n 64 --repeat_penalty 1.3 -p "test"
```

It should append the `this.home` path to the models

👍 
```
/root/dalai/alpaca/main --seed -1 --threads 4 --n_predict 200 --model /root/dalai/alpaca/models/13B/ggml-model-q4_0.bin --top_k 40 --top_p 0.9 --temp 0.8 --repeat_last_n 64 --repeat_penalty 1.3 -p "test"
```

This PR solved it and bump package to 0.3.2

Regards