### PR TITLE
Bugfix for saving model selection between sessions

### DIFF
--- a/bin/web/views/index.ejs
+++ b/bin/web/views/index.ejs
@@ -283,7 +283,7 @@ ${fields}
         const promptSelect = document.getElementById('prompt-select');
         const resetButton = document.querySelector("#prompt-reset")
         document.querySelector("form").addEventListener("input", (e) => {
-            if (e.target.tagName === "SELECT") {
+            if (e.target.tagName === "SELECT" && e.target.name === 'model') {
                 config[e.target.name] = config.models[e.target.selectedIndex]
             } else if (e.target.type === "checkbox") {
                 config[e.target.name] = e.target.checked


### PR DESCRIPTION
this was working but broke when a new dropdown component (prompt templates) were introduced. this bug fix restores the functionality of keeping model selection