### PR TITLE
fix: change response channel name from response to result

### DIFF
--- a/index.js
+++ b/index.js
@@ -547,7 +547,7 @@ class Dalai {
   connect(req, cb) {
     const socket = io(req.url)
     socket.emit('request', req)
-    socket.on('response', cb)
+    socket.on('result', cb)
     socket.on('error', function(e) {
       throw e
     });


### PR DESCRIPTION
hello,

i think there was a little typo in the response channel name.
on `result` was emitted but on `response` was listened, so i changed that.

hope this helps