### PR TITLE
fix: change value 'response' by value 'result' of event name when socket client is registered

### DIFF
--- a/index.js
+++ b/index.js
@@ -547,7 +547,7 @@ class Dalai {
   connect(req, cb) {
     const socket = io(req.url)
     socket.emit('request', req)
-    socket.on('response', cb)
+    socket.on('result', cb)
     socket.on('error', function(e) {
       throw e
     });


### PR DESCRIPTION
I have been working with the Dalai API to connect it with a simple client to run on node.js, following the example redacted in the readme

```javascript
const Dalai = require('dalai')
new Dalai().request({
  model: "7B",
  prompt: "The following is a conversation between a boy and a girl:",
}, (token) => {
  process.stdout.write(token)
})
```

The connection is established successfully, and the request launches the model to process the prompt, but the callback isn't called. However, the client connected and ready to listen from the web page receives the tokens series.

This occurs because the Dalai's request method has a typo. Currently, the event name expected is the `response` instead of the `result` string value.

[socket.on('response', cb)](https://github.com/cocktailpeanut/dalai/blob/e4f678efa274c08414227193b7c9607dd8f60db7/index.js#L550)

This 'result' string value is used in the javascript script on the web page when the socket client registers a callback to listen to the tokens received via WebSocket.

[socket.on('result',..](https://github.com/cocktailpeanut/dalai/blob/e4f678efa274c08414227193b7c9607dd8f60db7/bin/web/views/index.ejs#L408)
```
       socket.on('result', async({
            request,
            response
        })
```

I fix this issue by changing the event name used to register the callback of the API Dalai client, for that match with the event emitted from the server side and consumed by the view.