### PR TITLE
Replace image with copy-pastable installation script

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,13 @@ Run LLaMA and Alpaca on your computer.
 
 ## JUST RUN THIS
 
-<img src="npx2.png" class='round'>
+```sh
+# install model
+npx dalai llama install 7B
+
+# launch web UI + socket.io API
+npx dalai serve
+```
 
 ## TO GET
 


### PR DESCRIPTION
The first thing I wanted to do was "JUST RUN THIS". But the current image makes me carefully type it out, rather than copy-pasting.