### PR TITLE
feat: overcome download connection errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,8 @@ class Dalai {
     return encodedStr;
   }
   async down(url, dest, headers) {
-    const task = path.basename(dest);
+    const task = path.basename(dest)
+    this.startProgress(task)
 
     const download = new EasyDl(url, dest, {
       connections: 10,
@@ -123,10 +124,12 @@ class Dalai {
       recentError = error;
     });
 
-    const success = await download.wait();
+    download.start();
 
-    if (!success)
-      throw recentError || new Error("Download failed");
+    await new Promise((accept, reject) => {
+      download.once("end", () => accept());
+      download.once("close", () => reject(recentError) || new Error("download failed"));
+    });
 
     this.progressBar.update(1);
     term("\n");

--- a/llama.js
+++ b/llama.js
@@ -138,6 +138,7 @@ npx dalai install 7B 13B
     const resolvedPath = path.resolve(this.home, "models", model)
     await fs.promises.mkdir(resolvedPath, { recursive: true }).catch((e) => { })
 
+    const filesToDownload = [];
     for(let file of files) {
      if (fs.existsSync(path.resolve(resolvedPath, file))) {
        console.log(`Skip file download, it already exists: ${file}`)
@@ -145,12 +146,18 @@ npx dalai install 7B 13B
      }
 
       const url = `https://agi.gpt4.org/llama/LLaMA/${model}/${file}`
-      await this.root.down(url, path.resolve(resolvedPath, file), {
-        "User-Agent": "Mozilla/5.0"
-      })
+      filesToDownload.push({
+        url,
+        dest: path.resolve(resolvedPath, file),
+        headers: {
+          "User-Agent": "Mozilla/5.0"
+        }
+      });
     }
+    await this.root.multiDownload(filesToDownload);
 
     const files2 = ["tokenizer_checklist.chk", "tokenizer.model"]
+    const filesToDownload2 = [];
     for(let file of files2) {
 //      if (fs.existsSync(path.resolve(this.home, "models", file))) {
 //        console.log(`Skip file download, it already exists: ${file}`)
@@ -158,10 +165,15 @@ npx dalai install 7B 13B
 //      }
       const url = `https://agi.gpt4.org/llama/LLaMA/${file}`
       const dir = path.resolve(this.home, "models")
-      await this.root.down(url, path.resolve(dir, file), {
-        "User-Agent": "Mozilla/5.0"
-      })
+      filesToDownload2.push({
+        url,
+        dest: path.resolve(dir, file),
+        headers: {
+          "User-Agent": "Mozilla/5.0"
+        }
+      });
     }
+    await this.root.multiDownload(filesToDownload2);
 
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "postinstall": "node setup"
   },
   "dependencies": {
+    "chalk": "^4.1.2",
+    "cli-progress": "^3.12.0",
     "easydl": "^1.0.3",
     "ejs": "^3.1.8",
     "express": "^4.18.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "postinstall": "node setup"
   },
   "dependencies": {
+    "bytes": "^3.1.2",
     "chalk": "^4.1.2",
     "cli-progress": "^3.12.0",
     "easydl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postinstall": "node setup"
   },
   "dependencies": {
-    "axios": "^1.3.4",
+    "easydl": "^1.0.3",
     "ejs": "^3.1.8",
     "express": "^4.18.2",
     "isomorphic-git": "^1.22.0",


### PR DESCRIPTION
* Switched from `axios` to `easydl` library for downloading files since `easydl` overcomes connection errors better and also supports multithreaded downloads, significantly improving the download speed.
* Added support for downloading files in parallel to improve download speeds

<img width="614" alt="Screenshot 2023-04-12 at 18 31 22" src="https://user-images.githubusercontent.com/7817232/231507881-c3bb49bc-f87e-4468-866b-c9874518635f.png">

In the meantime, you can install this version of `dalai` by running this command:
```bash
npm install -g "github:giladgd/dalai#overcomeDownloadConnectionErrors"
```