### PR TITLE
Fix typo in readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -120,7 +120,7 @@ docker compose run dalai npx dalai alpaca install 7B # or a different model
 docker compose up -d
 ```
 
-This will dave the models in the `./models` folder
+This will save the models in the `./models` folder
 
 View the site at http://127.0.0.1:3000/
 


### PR DESCRIPTION
Under Quickstart -> Docker Compose there is a typo