### PR TITLE
Throw explicit error when there's a typo in the install command

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,6 +326,10 @@ class Dalai {
 
     let engine = this.cores[core]
 
+    if (!engine) {
+      throw new Error(`Unable to find engine for core: ${core}`)
+    }
+
     const venv_path = path.join(this.home, "venv")
     let ve = await exists(venv_path)
     if (!ve) {


### PR DESCRIPTION
Relevant issue: https://github.com/cocktailpeanut/dalai/issues/371

When running `npx dalai llama install [..]` if you don't spell "llama" correctly you'll get an error that doesn't indicate what's failing

```
ERROR TypeError: Cannot read properties of undefined (reading 'home')
    at Dalai.install ($HOME/.npm/_npx/3c737cbb02d79cc9/node_modules/dalai/index.js:337:43)
```

This will just be a bit more explicit